### PR TITLE
FIx: 공유 사용자 삭제 시 다른 사용자가 삭제되는 버그 수정

### DIFF
--- a/controllers/sharingController.js
+++ b/controllers/sharingController.js
@@ -102,7 +102,7 @@ const getSharedUsers = async (req, res, next) => {
         error: "존재하지 않습니다.",
       });
     }
-    
+
     const owner = await User.findById(collection.createdBy);
     const modefiedOwner = {
       _id: owner._id,
@@ -237,11 +237,14 @@ const deleteSharedUser = async (req, res, next) => {
         error: "존재하지 않습니다.",
       });
     }
-
     // 공유 + 즐겨찾기 문서 삭제
     await Promise.all([
-      CollectionFavorite.deleteOne({ collectionId }),
-      CollectionShare.deleteOne({ collectionId }),
+      CollectionFavorite.deleteOne({
+        collectionId: collectionId,
+        userId: userId,
+      }),
+      CollectionShare.deleteOne({ collectionId: collectionId, userId: userId }),
+      ,
     ]);
     return res.status(StatusCodes.OK).json({
       message: "사용자 삭제 완료",


### PR DESCRIPTION
 **공유 사용자 삭제 시 다른 사용자가 삭제되는 버그 수정**
- 전체 삭제되는 오류를 수정할 때 해당 부분을 고려하지 않아 버그 발생
- deleteOne에서 collecitonId + userId로 조회하여 삭제로 수정